### PR TITLE
Fix addon name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "zotero-pdf-metadata",
   "version": "0.5.6",
-  "description": "Zotero Addon",
+  "description": "Zotero PDF Metadata",
   "config": {
-    "addonName": "Zotero Addon",
+    "addonName": "Zotero PDF Metadata",
     "addonID": "zoteropdfmetadata@gmail.com",
     "addonRef": "pdfmetadata",
     "addonInstance": "PDFMetadata",


### PR DESCRIPTION
We created a plugin store page and our script reads the plugin name from XPI. This plugin can be better configured with templates to display the correct name in both Zotero and the web.

![image](https://github.com/franzbischoff/zotero-pdf-metadata/assets/44738481/55da44e5-afcf-4bab-a152-c592f1173d0c)

Thanks.